### PR TITLE
Look for dependencies in dep file directory rather than googBase

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -73,7 +73,7 @@ if (flags.closureLibraryBaseJsPath) {
     depsFiles.forEach(depFile => {
       const depFilePath = resolveFrom(`${process.cwd()}/package.json`, depFile);
       const depFileContents = fs.readFileSync(depFilePath, 'utf8');
-      parseGoogDeps(depFileContents, googBaseDir).forEach((filepath, namespace) => {
+      parseGoogDeps(depFileContents, path.dirname(depFilePath)).forEach((filepath, namespace) => {
         googPathsByNamespace.set(namespace, filepath);
       });
     });

--- a/lib/parse-goog-deps.js
+++ b/lib/parse-goog-deps.js
@@ -5,9 +5,9 @@ const path = require('path');
 /**
  *
  * @param {string} contents
- * @param {string} googBaseDir full path to the closure-library
+ * @param {string} baseDir full path to the closure-library
  */
-module.exports = function parseGoogDeps(contents, googBaseDir) {
+module.exports = function parseGoogDeps(contents, baseDir) {
   const googPathsByNamespace = new Map();
   const ast = acorn.Parser.parse(contents, {ecmaVersion: 2020});
   walk.simple(ast, {
@@ -17,7 +17,7 @@ module.exports = function parseGoogDeps(contents, googBaseDir) {
           node.callee.object.name === 'goog' &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'addDependency') {
-        const filePath = path.resolve(googBaseDir, node.arguments[0].value);
+        const filePath = path.resolve(baseDir, node.arguments[0].value);
         node.arguments[1].elements.forEach((arg) => googPathsByNamespace.set(arg.value, filePath));
       }
     }


### PR DESCRIPTION
Sometimes, additional dependencies are not located in the same directory as the closure library dependencies. This modifies the file search slightly to search in the directory where the dependency file is located. 

Another benefit of this is that dependencies can be properly scoped inside their own project directory (e.g. `tools/module.js` instead of `../../../@scope/shared-library/tools/module.js`).